### PR TITLE
Fix typo to allow proper git ssh packages

### DIFF
--- a/platformio/managers/platform.py
+++ b/platformio/managers/platform.py
@@ -638,7 +638,7 @@ class PlatformBase(PlatformPackagesMixin, PlatformRunMixin):
             name = item
             version = "*"
             if "@" in item:
-                name, version = item.split("@", 2)
+                name, version = item.split("@", 1)
             name = name.strip()
             if name not in packages:
                 packages[name] = {}


### PR DESCRIPTION
Calling `string.split("@",2)` does not split into up to two pieces. It splits up to twice, resulting in up to three pieces. This breaks when using a version string that includes a "@" symbol, such as `git@github.com:user/repo.git` in a project's configuration file.